### PR TITLE
close <ul> tag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,6 +100,7 @@ function listRelatedPosts(options) {
         result += '<li class="' + options.liClass + '">' + '<a href="' + root + postList[i].path + '">' + postList[i].title + '</a></li>';
       }
     }
+    result += '</ul>';
   }
 
   return result;


### PR DESCRIPTION
Generated HTML markup is invalid because the closing `</ul>` tag is missing. This pull request outputs a `</ul>` tag at the end.