### PR TITLE
allow customization of class names of p and a tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Add `<%- list_related_posts([options]) %>` in template file for article.
 | option | description | default |
 | :--- | :--- | :--- |
 | maxCount| Maximum count of a list | `5` |
+| pClass| Class name of p when there is no related post | `'related-posts-none'` |
 | ulClass| Class name of ul | `'related-posts'` |
 | liClass| Class name of li | `'related-posts-item'` |
+| aClass| Class name of a | `'related-posts-link'` |
 | generateAbstract| Generate abstract or not | `false` |
 | abstractClass| Class name of abstract of content | `'related-posts-item-abstract'` |
 | abstractLength| Length of abstract | `110` |

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,8 +50,10 @@ function listRelatedPosts(options) {
 
   options = assign({
     maxCount: 5,
+    pClass: 'related-posts-none',
     ulClass: 'related-posts',
     liClass: 'related-posts-item',
+    aClass: 'related-posts-link',
     generateAbstract: false,
     abstractClass: 'related-posts-item-abstract',
     abstractLength: 110,
@@ -88,16 +90,16 @@ function listRelatedPosts(options) {
   var count = Math.min(options.maxCount, postList.length);
 
   if(count === 0){
-    result += '<p>No related post.</p>';
+    result += '<p class="' + options.pClass + '">No related post.</p>';
   }else{
     result += '<ul class="' + options.ulClass + '">';
     if (options.generateAbstract) {
       for (var i = 0; i < count; i++) {
-        result += '<li class="' + options.liClass + '">' + '<a href="' + root + postList[i].path + '">' + postList[i].title + '</a><div class="' + options.abstractClass + '">' + striptags(postList[i].content).substring(0, options.abstractLength) + '</div></li>';
+        result += '<li class="' + options.liClass + '">' + '<a class="' + options.aClass + '" href="' + root + postList[i].path + '">' + postList[i].title + '</a><div class="' + options.abstractClass + '">' + striptags(postList[i].content).substring(0, options.abstractLength) + '</div></li>';
       }
     } else {
       for (var i = 0; i < count; i++) {
-        result += '<li class="' + options.liClass + '">' + '<a href="' + root + postList[i].path + '">' + postList[i].title + '</a></li>';
+        result += '<li class="' + options.liClass + '">' + '<a class="' + options.aClass + '" href="' + root + postList[i].path + '">' + postList[i].title + '</a></li>';
       }
     }
   }


### PR DESCRIPTION
This change introduces `pClass` config option, which allows the template to customize the style of `<p>No related post.</p>` element. For example, the template could hide this element, or use a gray font color.

This change introduces `aClass` config option, which allows the template to customize the style of `<a>` elements linking to posts. This is especially useful in a template based on [Pure CSS](https://github.com/yahoo/pure), whose *Menus* style requires `pure-menu-link` class on `<a>` elements.